### PR TITLE
Fixed the Color Picker Component

### DIFF
--- a/resources/views/components/forms/inputs/color-picker.blade.php
+++ b/resources/views/components/forms/inputs/color-picker.blade.php
@@ -21,6 +21,7 @@
         id="{{ $id }}-input"
         name="{{ $name }}"
         type="hidden"
-        @if($value)value="{{ $value }}"@endif
+        {{-- If there's no value from old(), use value from the default option instead. --}}
+        @if(!empty($value))value="{{ $value }}"@elseif(!empty($options()['default']))value="{{ $options()['default'] }}"@endif
     />
 </div>

--- a/src/Components/Forms/Inputs/ColorPicker.php
+++ b/src/Components/Forms/Inputs/ColorPicker.php
@@ -17,6 +17,15 @@ class ColorPicker extends Input
     {
         parent::__construct($name, $id, 'hidden', $value);
 
+        /**
+         * The default option was overwriting the value from old() input when $options is merged with\
+         * the options() array.
+         * Instead, if there's a value from $this->value, it's gonna overwrite the default value in $options.
+         */
+        if (! empty($this->value) && ! empty($options['default'])) {
+            $options['default'] = $this->value;
+        }
+
         $this->options = $options;
     }
 


### PR DESCRIPTION
Color Picker now have a initial value based on default option.
Before this, when first time rendering the view, the color picker
doesn't actually have a value inserted although the default option have
be set. There should now be a value inserted based on the default option
value so user doesn't have to click the Color Picker and click save
to set the value.

Also, fixed where the default option value overwriting old() value.