### PR TITLE
Support old values for nested form fields #61

### DIFF
--- a/resources/views/components/editors/easy-mde.blade.php
+++ b/resources/views/components/editors/easy-mde.blade.php
@@ -4,4 +4,4 @@
     name="{{ $name }}"
     id="{{ $id }}"
     {{ $attributes }}
->{{ old($name, $slot) }}</textarea>
+>{{ old($dotName, $slot) }}</textarea>

--- a/resources/views/components/editors/easy-mde.blade.php
+++ b/resources/views/components/editors/easy-mde.blade.php
@@ -4,4 +4,4 @@
     name="{{ $name }}"
     id="{{ $id }}"
     {{ $attributes }}
->{{ old($dotName, $slot) }}</textarea>
+>{{ old(Str::dot($name), $slot) }}</textarea>

--- a/resources/views/components/editors/trix.blade.php
+++ b/resources/views/components/editors/trix.blade.php
@@ -1,4 +1,4 @@
 <div {{ $attributes }}>
-    <input name="{{ $name }}" id="{{ $id }}" value="{{ old($name, $slot) }}" type="hidden">
+    <input name="{{ $name }}" id="{{ $id }}" value="{{ old($dotName, $slot) }}" type="hidden">
     <trix-editor input="{{ $id }}" class="{{ $styling }}"></trix-editor>
 </div>

--- a/resources/views/components/editors/trix.blade.php
+++ b/resources/views/components/editors/trix.blade.php
@@ -1,4 +1,4 @@
 <div {{ $attributes }}>
-    <input name="{{ $name }}" id="{{ $id }}" value="{{ old($dotName, $slot) }}" type="hidden">
+    <input name="{{ $name }}" id="{{ $id }}" value="{{ old(Str::dot($name), $slot) }}" type="hidden">
     <trix-editor input="{{ $id }}" class="{{ $styling }}"></trix-editor>
 </div>

--- a/resources/views/components/forms/inputs/textarea.blade.php
+++ b/resources/views/components/forms/inputs/textarea.blade.php
@@ -3,4 +3,4 @@
     id="{{ $id }}"
     rows="{{ $rows }}"
     {{ $attributes }}
->{{ old($dotName, $slot) }}</textarea>
+>{{ old(Str::dot($name), $slot) }}</textarea>

--- a/resources/views/components/forms/inputs/textarea.blade.php
+++ b/resources/views/components/forms/inputs/textarea.blade.php
@@ -3,4 +3,4 @@
     id="{{ $id }}"
     rows="{{ $rows }}"
     {{ $attributes }}
->{{ old($name, $slot) }}</textarea>
+>{{ old($dotName, $slot) }}</textarea>

--- a/src/BladeUIKitServiceProvider.php
+++ b/src/BladeUIKitServiceProvider.php
@@ -32,6 +32,7 @@ final class BladeUIKitServiceProvider extends ServiceProvider
         $this->bootBladeComponents();
         $this->bootLivewireComponents();
         $this->bootDirectives();
+        $this->bootMacros();
         $this->bootPublishing();
     }
 
@@ -102,6 +103,13 @@ final class BladeUIKitServiceProvider extends ServiceProvider
 
         Blade::directive('bukScripts', function (string $expression) {
             return "<?php echo BladeUIKit\\BladeUIKit::outputScripts($expression); ?>";
+        });
+    }
+
+    private function bootMacros(): void
+    {
+        Str::macro('dot', function ($subject) {
+            return trim(str_replace(['[', ']', '..'], '.', $subject), '.');
         });
     }
 

--- a/src/Components/Editors/EasyMDE.php
+++ b/src/Components/Editors/EasyMDE.php
@@ -6,14 +6,12 @@ namespace BladeUIKit\Components\Editors;
 
 use BladeUIKit\Components\BladeComponent;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class EasyMDE extends BladeComponent
 {
     /** @var string */
     public $name;
-
-    /** @var string */
-    public $dotName;
 
     /** @var string */
     public $id;
@@ -26,9 +24,8 @@ class EasyMDE extends BladeComponent
     public function __construct(string $name, string $id = null, array $options = [])
     {
         $this->name = $name;
-        $this->id = $id ?? $name;
+        $this->id = $id ?? str_replace('.', '_', Str::dot($name));
         $this->options = $options;
-        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
     }
 
     public function options(): array

--- a/src/Components/Editors/EasyMDE.php
+++ b/src/Components/Editors/EasyMDE.php
@@ -13,6 +13,9 @@ class EasyMDE extends BladeComponent
     public $name;
 
     /** @var string */
+    public $dotName;
+
+    /** @var string */
     public $id;
 
     /** @var array */
@@ -25,6 +28,7 @@ class EasyMDE extends BladeComponent
         $this->name = $name;
         $this->id = $id ?? $name;
         $this->options = $options;
+        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
     }
 
     public function options(): array

--- a/src/Components/Editors/Trix.php
+++ b/src/Components/Editors/Trix.php
@@ -6,14 +6,12 @@ namespace BladeUIKit\Components\Editors;
 
 use BladeUIKit\Components\BladeComponent;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class Trix extends BladeComponent
 {
     /** @var string */
     public $name;
-
-    /** @var string */
-    public $dotName;
 
     /** @var string */
     public $id;
@@ -26,9 +24,8 @@ class Trix extends BladeComponent
     public function __construct(string $name, string $id = null, string $styling = 'trix-content')
     {
         $this->name = $name;
-        $this->id = $id ?? $name;
+        $this->id = $id ?? str_replace('.', '_', Str::dot($name));
         $this->styling = $styling;
-        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
     }
 
     public function render(): View

--- a/src/Components/Editors/Trix.php
+++ b/src/Components/Editors/Trix.php
@@ -13,6 +13,9 @@ class Trix extends BladeComponent
     public $name;
 
     /** @var string */
+    public $dotName;
+
+    /** @var string */
     public $id;
 
     /** @var string */
@@ -25,6 +28,7 @@ class Trix extends BladeComponent
         $this->name = $name;
         $this->id = $id ?? $name;
         $this->styling = $styling;
+        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
     }
 
     public function render(): View

--- a/src/Components/Forms/Error.php
+++ b/src/Components/Forms/Error.php
@@ -18,7 +18,7 @@ class Error extends BladeComponent
 
     public function __construct(string $field, string $bag = 'default')
     {
-        $this->field = $field;
+        $this->field = trim(str_replace(['[', ']', '..'], '.', $field), '.');
         $this->bag = $bag;
     }
 

--- a/src/Components/Forms/Error.php
+++ b/src/Components/Forms/Error.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BladeUIKit\Components\Forms;
 
 use BladeUIKit\Components\BladeComponent;
+use Illuminate\Support\Str;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\View\View;
 
@@ -18,7 +19,7 @@ class Error extends BladeComponent
 
     public function __construct(string $field, string $bag = 'default')
     {
-        $this->field = trim(str_replace(['[', ']', '..'], '.', $field), '.');
+        $this->field = Str::dot($field);
         $this->bag = $bag;
     }
 

--- a/src/Components/Forms/Inputs/Checkbox.php
+++ b/src/Components/Forms/Inputs/Checkbox.php
@@ -15,7 +15,7 @@ class Checkbox extends Input
     {
         parent::__construct($name, $id, 'checkbox');
 
-        $this->checked = (bool) old($name, $checked);
+        $this->checked = (bool) old($this->dotName, $checked);
     }
 
     public function render(): View

--- a/src/Components/Forms/Inputs/Checkbox.php
+++ b/src/Components/Forms/Inputs/Checkbox.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BladeUIKit\Components\Forms\Inputs;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class Checkbox extends Input
 {
@@ -15,7 +16,7 @@ class Checkbox extends Input
     {
         parent::__construct($name, $id, 'checkbox');
 
-        $this->checked = (bool) old($this->dotName, $checked);
+        $this->checked = (bool) old(Str::dot($name), $checked);
     }
 
     public function render(): View

--- a/src/Components/Forms/Inputs/Input.php
+++ b/src/Components/Forms/Inputs/Input.php
@@ -13,6 +13,9 @@ class Input extends BladeComponent
     public $name;
 
     /** @var string */
+    public $dotName;
+
+    /** @var string */
     public $id;
 
     /** @var string */
@@ -26,7 +29,8 @@ class Input extends BladeComponent
         $this->name = $name;
         $this->id = $id ?? $name;
         $this->type = $type;
-        $this->value = old($name, $value ?? '');
+        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
+        $this->value = old($this->dotName, $value ?? '');
     }
 
     public function render(): View

--- a/src/Components/Forms/Inputs/Input.php
+++ b/src/Components/Forms/Inputs/Input.php
@@ -6,14 +6,12 @@ namespace BladeUIKit\Components\Forms\Inputs;
 
 use BladeUIKit\Components\BladeComponent;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class Input extends BladeComponent
 {
     /** @var string */
     public $name;
-
-    /** @var string */
-    public $dotName;
 
     /** @var string */
     public $id;
@@ -27,10 +25,9 @@ class Input extends BladeComponent
     public function __construct(string $name, string $id = null, string $type = 'text', ?string $value = '')
     {
         $this->name = $name;
-        $this->id = $id ?? $name;
+        $this->id = $id ?? str_replace('.', '_', Str::dot($name));
         $this->type = $type;
-        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
-        $this->value = old($this->dotName, $value ?? '');
+        $this->value = old(Str::dot($name), $value ?? '');
     }
 
     public function render(): View

--- a/src/Components/Forms/Inputs/Textarea.php
+++ b/src/Components/Forms/Inputs/Textarea.php
@@ -13,6 +13,9 @@ class Textarea extends BladeComponent
     public $name;
 
     /** @var string */
+    public $dotName;
+
+    /** @var string */
     public $id;
 
     /** @var int */
@@ -23,6 +26,7 @@ class Textarea extends BladeComponent
         $this->name = $name;
         $this->id = $id ?? $name;
         $this->rows = $rows;
+        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
     }
 
     public function render(): View

--- a/src/Components/Forms/Inputs/Textarea.php
+++ b/src/Components/Forms/Inputs/Textarea.php
@@ -6,14 +6,12 @@ namespace BladeUIKit\Components\Forms\Inputs;
 
 use BladeUIKit\Components\BladeComponent;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class Textarea extends BladeComponent
 {
     /** @var string */
     public $name;
-
-    /** @var string */
-    public $dotName;
 
     /** @var string */
     public $id;
@@ -24,9 +22,8 @@ class Textarea extends BladeComponent
     public function __construct(string $name, string $id = null, $rows = 3)
     {
         $this->name = $name;
-        $this->id = $id ?? $name;
+        $this->id = $id ?? str_replace('.', '_', Str::dot($name));
         $this->rows = $rows;
-        $this->dotName = trim(str_replace(['[', ']', '..'], '.', $name), '.');
     }
 
     public function render(): View

--- a/tests/Components/Editors/EasyMDETest.php
+++ b/tests/Components/Editors/EasyMDETest.php
@@ -31,6 +31,18 @@ HTML;
     }
 
     /** @test */
+    public function nested_editor_can_have_old_values()
+    {
+        $this->flashOld(['profile.about' => 'About me text']);
+
+        $expected = <<<HTML
+<textarea x-data x-init="new EasyMDE({ element: \$el , ...{&quot;forceSync&quot;:true} })" name="profile[about]" id="profile[about]">About me text</textarea>
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-easy-mde name="profile[about]"/>');
+    }
+
+    /** @test */
     public function editor_can_have_options()
     {
         $this->assertComponentRenders(

--- a/tests/Components/Editors/EasyMDETest.php
+++ b/tests/Components/Editors/EasyMDETest.php
@@ -36,7 +36,7 @@ HTML;
         $this->flashOld(['profile.about' => 'About me text']);
 
         $expected = <<<HTML
-<textarea x-data x-init="new EasyMDE({ element: \$el , ...{&quot;forceSync&quot;:true} })" name="profile[about]" id="profile[about]">About me text</textarea>
+<textarea x-data x-init="new EasyMDE({ element: \$el , ...{&quot;forceSync&quot;:true} })" name="profile[about]" id="profile_about">About me text</textarea>
 HTML;
 
         $this->assertComponentRenders($expected, '<x-easy-mde name="profile[about]"/>');

--- a/tests/Components/Editors/TrixTest.php
+++ b/tests/Components/Editors/TrixTest.php
@@ -37,4 +37,20 @@ HTML;
 
         $this->assertComponentRenders($expected, '<x-trix name="about"/>');
     }
+
+    /** @test */
+    public function nested_editor_can_have_old_values()
+    {
+        $this->flashOld(['profile.about' => 'About me text']);
+
+        $expected = <<<HTML
+<div>
+    <input name="profile[about]" id="profile[about]" value="About me text" type="hidden">
+    <trix-editor input="profile[about]" class="trix-content">
+    </trix-editor>
+</div>
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-trix name="profile[about]"/>');
+    }
 }

--- a/tests/Components/Editors/TrixTest.php
+++ b/tests/Components/Editors/TrixTest.php
@@ -45,8 +45,8 @@ HTML;
 
         $expected = <<<HTML
 <div>
-    <input name="profile[about]" id="profile[about]" value="About me text" type="hidden">
-    <trix-editor input="profile[about]" class="trix-content">
+    <input name="profile[about]" id="profile_about" value="About me text" type="hidden">
+    <trix-editor input="profile_about" class="trix-content">
     </trix-editor>
 </div>
 HTML;

--- a/tests/Components/Forms/ErrorTest.php
+++ b/tests/Components/Forms/ErrorTest.php
@@ -48,4 +48,18 @@ HTML;
 
         $this->assertComponentRenders($expected, $template);
     }
+
+    /** @test */
+    public function it_supports_field_names_in_array_notation()
+    {
+        $this->withViewErrors(['profile.first_name' => 'Incorrect first name.']);
+
+        $expected = <<<HTML
+<div class="text-red-500">
+    Incorrect first name.
+</div>
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-error field="profile[first_name]" class="text-red-500"/>');
+    }
 }

--- a/tests/Components/Forms/Inputs/CheckboxTest.php
+++ b/tests/Components/Forms/Inputs/CheckboxTest.php
@@ -36,4 +36,15 @@ class CheckboxTest extends ComponentTestCase
             '<x-checkbox name="remember_me"/>'
         );
     }
+
+    /** @test */
+    public function nested_inputs_can_have_old_values()
+    {
+        $this->flashOld(['login.remember_me' => true]);
+
+        $this->assertComponentRenders(
+            '<input name="login[remember_me]" type="checkbox" id="login[remember_me]" checked />',
+            '<x-checkbox name="login[remember_me]"/>'
+        );
+    }
 }

--- a/tests/Components/Forms/Inputs/CheckboxTest.php
+++ b/tests/Components/Forms/Inputs/CheckboxTest.php
@@ -43,7 +43,7 @@ class CheckboxTest extends ComponentTestCase
         $this->flashOld(['login.remember_me' => true]);
 
         $this->assertComponentRenders(
-            '<input name="login[remember_me]" type="checkbox" id="login[remember_me]" checked />',
+            '<input name="login[remember_me]" type="checkbox" id="login_remember_me" checked />',
             '<x-checkbox name="login[remember_me]"/>'
         );
     }

--- a/tests/Components/Forms/Inputs/EmailTest.php
+++ b/tests/Components/Forms/Inputs/EmailTest.php
@@ -36,4 +36,15 @@ class EmailTest extends ComponentTestCase
             '<x-email/>'
         );
     }
+
+    /** @test */
+    public function nested_inputs_can_have_old_values()
+    {
+        $this->flashOld(['profile.email' => 'Eloquent']);
+
+        $this->assertComponentRenders(
+            '<input name="profile[email]" type="email" id="profile[email]" value="Eloquent" />',
+            '<x-email name="profile[email]"/>'
+        );
+    }
 }

--- a/tests/Components/Forms/Inputs/EmailTest.php
+++ b/tests/Components/Forms/Inputs/EmailTest.php
@@ -43,7 +43,7 @@ class EmailTest extends ComponentTestCase
         $this->flashOld(['profile.email' => 'Eloquent']);
 
         $this->assertComponentRenders(
-            '<input name="profile[email]" type="email" id="profile[email]" value="Eloquent" />',
+            '<input name="profile[email]" type="email" id="profile_email" value="Eloquent" />',
             '<x-email name="profile[email]"/>'
         );
     }

--- a/tests/Components/Forms/Inputs/InputTest.php
+++ b/tests/Components/Forms/Inputs/InputTest.php
@@ -43,7 +43,7 @@ class InputTest extends ComponentTestCase
         $this->flashOld(['filters.search' => 'Eloquent']);
 
         $this->assertComponentRenders(
-            '<input name="filters[search]" type="text" id="filters[search]" value="Eloquent" />',
+            '<input name="filters[search]" type="text" id="filters_search" value="Eloquent" />',
             '<x-input name="filters[search]" />'
         );
     }

--- a/tests/Components/Forms/Inputs/InputTest.php
+++ b/tests/Components/Forms/Inputs/InputTest.php
@@ -36,4 +36,15 @@ class InputTest extends ComponentTestCase
             '<x-input name="search" />'
         );
     }
+
+    /** @test */
+    public function nested_inputs_can_have_old_values()
+    {
+        $this->flashOld(['filters.search' => 'Eloquent']);
+
+        $this->assertComponentRenders(
+            '<input name="filters[search]" type="text" id="filters[search]" value="Eloquent" />',
+            '<x-input name="filters[search]" />'
+        );
+    }
 }

--- a/tests/Components/Forms/Inputs/PasswordTest.php
+++ b/tests/Components/Forms/Inputs/PasswordTest.php
@@ -36,4 +36,15 @@ class PasswordTest extends ComponentTestCase
             '<x-password/>'
         );
     }
+
+    /** @test */
+    public function nested_inputs_cannot_have_old_values()
+    {
+        $this->flashOld(['login.password' => 'secret']);
+
+        $this->assertComponentRenders(
+            '<input name="login[password]" type="password" id="login[password]" />',
+            '<x-password name="login[password]"/>'
+        );
+    }
 }

--- a/tests/Components/Forms/Inputs/PasswordTest.php
+++ b/tests/Components/Forms/Inputs/PasswordTest.php
@@ -43,7 +43,7 @@ class PasswordTest extends ComponentTestCase
         $this->flashOld(['login.password' => 'secret']);
 
         $this->assertComponentRenders(
-            '<input name="login[password]" type="password" id="login[password]" />',
+            '<input name="login[password]" type="password" id="login_password" />',
             '<x-password name="login[password]"/>'
         );
     }

--- a/tests/Components/Forms/Inputs/PikadayTest.php
+++ b/tests/Components/Forms/Inputs/PikadayTest.php
@@ -36,7 +36,7 @@ HTML;
         $this->flashOld(['profile.birthday' => '23/03/1989']);
 
         $expected = <<<HTML
-<input x-data x-init="new Pikaday({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="profile[birthday]" type="text" id="profile[birthday]" placeholder="DD/MM/YYYY" value="23/03/1989" />
+<input x-data x-init="new Pikaday({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="profile[birthday]" type="text" id="profile_birthday" placeholder="DD/MM/YYYY" value="23/03/1989" />
 HTML;
 
         $this->assertComponentRenders($expected, '<x-pikaday name="profile[birthday]"/>');

--- a/tests/Components/Forms/Inputs/PikadayTest.php
+++ b/tests/Components/Forms/Inputs/PikadayTest.php
@@ -29,4 +29,16 @@ HTML;
 
         $this->assertComponentRenders($expected, '<x-pikaday name="birthday"/>');
     }
+
+    /** @test */
+    public function nested_pikaday_can_have_old_values()
+    {
+        $this->flashOld(['profile.birthday' => '23/03/1989']);
+
+        $expected = <<<HTML
+<input x-data x-init="new Pikaday({ field: \$el , ...{&quot;format&quot;:&quot;DD\/MM\/YYYY&quot;} })" name="profile[birthday]" type="text" id="profile[birthday]" placeholder="DD/MM/YYYY" value="23/03/1989" />
+HTML;
+
+        $this->assertComponentRenders($expected, '<x-pikaday name="profile[birthday]"/>');
+    }
 }

--- a/tests/Components/Forms/Inputs/TextareaTest.php
+++ b/tests/Components/Forms/Inputs/TextareaTest.php
@@ -36,4 +36,15 @@ class TextareaTest extends ComponentTestCase
             '<x-textarea name="about"/>'
         );
     }
+
+    /** @test */
+    public function nested_inputs_can_have_old_values()
+    {
+        $this->flashOld(['profile.about' => 'About me text']);
+
+        $this->assertComponentRenders(
+            '<textarea name="profile[about]" id="profile[about]" rows="3">About me text</textarea>',
+            '<x-textarea name="profile[about]"/>'
+        );
+    }
 }

--- a/tests/Components/Forms/Inputs/TextareaTest.php
+++ b/tests/Components/Forms/Inputs/TextareaTest.php
@@ -43,7 +43,7 @@ class TextareaTest extends ComponentTestCase
         $this->flashOld(['profile.about' => 'About me text']);
 
         $this->assertComponentRenders(
-            '<textarea name="profile[about]" id="profile[about]" rows="3">About me text</textarea>',
+            '<textarea name="profile[about]" id="profile_about" rows="3">About me text</textarea>',
             '<x-textarea name="profile[about]"/>'
         );
     }


### PR DESCRIPTION
This PR respects old form input values even if the input is named using nested "array notation". Old values for form inputs with names like profile[email] and employees[0][first_name] will work just like any other field.

I also added array notation support to the <x-error> component so that it is symmetric with form inputs:

<x-error field="cars[1][model]"/> or <x-error field="cars.1.model"/> both fetch the same error messages now.